### PR TITLE
feat: add mcp-get compatibility support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shane Hall (Fast Transients LLC)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 A Model Context Protocol (MCP) server for the Lodgify vacation rental API. Provides tools for managing properties, bookings, and calendar data.
 
+## Installation
+
+### Via mcp-get (Recommended)
+
+```bash
+npx @michaellatman/mcp-get@latest install lodgify
+```
+
+### Via uv (Direct)
+
+```bash
+uvx lodgify-mcp-server
+```
+
+### Manual Installation
+
+```bash
+uv add lodgify-mcp-server
+```
+
 ## Quick Start
 
 ### Claude Desktop Integration (Recommended)
@@ -11,8 +31,25 @@ Add this configuration to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-    "lodgify-api": {
-      "command": "docker",      "args": [
+    "lodgify": {
+      "command": "uvx",
+      "args": ["lodgify-mcp-server"],
+      "env": {
+        "LODGIFY_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+**Alternative Docker configuration:**
+
+```json
+{
+  "mcpServers": {
+    "lodgify-docker": {
+      "command": "docker",
+      "args": [
         "run", "-i", "--rm", 
         "-e", "LODGIFY_API_KEY=your_api_key_here",
         "ghcr.io/fast-transients/lodgify-mcp-server:latest",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this configuration to your Claude Desktop config file:
       "command": "uvx",
       "args": ["lodgify-mcp-server"],
       "env": {
-        "LODGIFY_API_KEY": "your-api-key-here"
+        "LODGIFY_API_KEY": "your_api_key_here"
       }
     }
   }

--- a/mcp.json
+++ b/mcp.json
@@ -6,7 +6,7 @@
         "lodgify-mcp-server"
       ],
       "env": {
-        "LODGIFY_API_KEY": "your-api-key-here"
+        "LODGIFY_API_KEY": ""
       }
     }
   }

--- a/mcp.json
+++ b/mcp.json
@@ -6,7 +6,7 @@
         "lodgify-mcp-server"
       ],
       "env": {
-        "LODGIFY_API_KEY": ""
+        "LODGIFY_API_KEY": "your_api_key_here"
       }
     }
   }

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "lodgify": {
+      "command": "uvx",
+      "args": [
+        "lodgify-mcp-server"
+      ],
+      "env": {
+        "LODGIFY_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-only-include = ["lodgify_server.py", "entrypoint.py"]
+packages = ["."]
+only-include = ["lodgify_server.py", "entrypoint.py", "mcp.json"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["."]
 only-include = ["lodgify_server.py", "entrypoint.py", "mcp.json"]
 
 [tool.ruff]


### PR DESCRIPTION
## What this PR does
Adds compatibility with the mcp-get registry system, allowing users to easily install and configure the Lodgify MCP server.

## Changes
- ✅ Add `mcp.json` configuration for uvx deployment
- ✅ Update `pyproject.toml` to include mcp.json in wheel packaging
- ✅ Add mcp-get installation instructions to README
- ✅ Support both uvx and Docker deployment methods

## Installation methods now supported
- `npx @michaellatman/mcp-get install lodgify` (via mcp-get)
- `uvx lodgify-mcp-server` (direct uv)
- Docker (existing method)

## Testing
- ✅ Docker build passes
- ✅ Package includes all necessary files
- ✅ mcp.json format validated