### PR TITLE
Fix parameter typing and annotate entrypoint

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -15,7 +15,7 @@ HTTP_FORBIDDEN = 403
 HTTP_SERVER_ERROR = 500
 API_KEY_MASK_LENGTH = 8
 
-def test_api_connection():  # noqa: PLR0911
+def test_api_connection() -> bool:  # noqa: PLR0911
     """Test the Lodgify API connection."""
     print("Testing Lodgify API connection...", file=sys.stderr)
     try:
@@ -78,7 +78,7 @@ def test_api_connection():  # noqa: PLR0911
         print(f"❌ API connection error: {e}", file=sys.stderr)
         return False
 
-def run_mcp_server():
+def run_mcp_server() -> None:
     """Run the MCP server."""
     try:
         # Ensure we have an API key for server mode
@@ -95,8 +95,11 @@ def run_mcp_server():
         # Set up proper signal handling for graceful shutdown
         import signal
 
-        def signal_handler(signum, frame):
-            print(f"\n🛑 Received signal {signum}, shutting down gracefully...", file=sys.stderr)
+        def signal_handler(signum: int, frame: object) -> None:
+            print(
+                f"\n🛑 Received signal {signum}, shutting down gracefully...",
+                file=sys.stderr,
+            )
             sys.exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)
@@ -112,7 +115,7 @@ def run_mcp_server():
         print(f"❌ Server error: {e}", file=sys.stderr)
         sys.exit(1)
 
-def show_info():
+def show_info() -> None:
     """Show information about the MCP server."""
     print("🏨 Lodgify MCP Server", file=sys.stderr)
     print("=" * 40, file=sys.stderr)

--- a/lodgify_server.py
+++ b/lodgify_server.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.prompts import base
+from mcp.server.fastmcp import Context, FastMCP  # type: ignore[import-not-found]
+from mcp.server.fastmcp.prompts import base  # type: ignore[import-not-found]
 
 # Constants
 HTTP_OK = 200
@@ -289,7 +289,7 @@ async def get_properties(
     """
     client = get_client()
 
-    params = {"limit": limit, "offset": offset}
+    params: dict[str, Any] = {"limit": limit, "offset": offset}
     if status:
         params["status"] = status
 
@@ -360,7 +360,7 @@ async def get_bookings(
     """
     client = get_client()
 
-    params = {"size": size, "page": page }
+    params: dict[str, Any] = {"size": size, "page": page }
     if property_id:
         params["property_id"] = property_id
     if status:
@@ -485,7 +485,7 @@ async def get_calendar(
     """
     client = get_client()
 
-    params = {"HouseId": property_id}
+    params: dict[str, Any] = {"HouseId": property_id}
     if room_type_id:
         params["RoomTypeId"] = room_type_id
     if start_date:


### PR DESCRIPTION
## Summary
- fix bug where HTTP parameter dictionaries were typed as `dict[str, int]`
- add annotations in entrypoint to satisfy mypy
- silence mypy import warnings for `mcp` dependencies

## Testing
- `ruff check`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b2fb7684832684c61fc75ef4d47e