### PR TITLE
Fix PyPI publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main, master ]
+  release:
+    types: [ published ]
   workflow_dispatch:
 
 jobs:
@@ -79,7 +81,9 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))
     environment:
       name: pypi
       url: https://pypi.org/project/lodgify-mcp-server/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    # Trigger the publish job when a new version tag is pushed (push event) or when a release is published (release event).
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))


### PR DESCRIPTION
## Summary
- run publish workflow when a GitHub release is published
- handle release events in the publish job condition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6a79625c8326b64d673748b726dc